### PR TITLE
Transcript functionality

### DIFF
--- a/src/components/AudioPlayer.js
+++ b/src/components/AudioPlayer.js
@@ -91,7 +91,7 @@ function AudioPlayer(props) {
     if (currentText) {
       currentText.scrollIntoView({
         behavior: 'smooth',
-        block: 'start'
+        block: 'center'
       });
     }
   };

--- a/src/components/AudioTranscript.js
+++ b/src/components/AudioTranscript.js
@@ -67,7 +67,6 @@ function AudioTranscript(props) {
   const theme = useTheme();
   const audioRef = useRef(null);
   const textRefs = useRef([]);
-  const timestampPrecision = 1000; // milliseconds
 
   useEffect(() => {
     const handleClick = (event, idx) => {
@@ -76,10 +75,11 @@ function AudioTranscript(props) {
       audioRef.current.currentTime = start;
       textRefs.current[idx].scrollIntoView({
         behavior: 'smooth',
-        block: 'start'
+        block: 'center'
       });
     }
     const processTranscript = (transcript, handleClick) => {
+      let timestampPrecision = 1000; // milliseconds
       return transcript.map(([sentence, start, duration, speakerId], idx) =>
         <p key={idx}>
           <span
@@ -98,13 +98,16 @@ function AudioTranscript(props) {
   }, [transcriptJSON]);
 
   useEffect(() => {
+    // const speakerColors = [theme.palette.primary.main, 'dodgerblue']; // temporary colors
     audioRef.current.addEventListener('timeupdate', (event) => {
       let currentTime = event.target.currentTime;
       if (textRefs.current[0]) {
         textRefs.current.forEach(text => {
           let start = text.dataset.start;
           let end = text.dataset.end;
+          // let speaker = text.dataset.speaker;
           if (currentTime >= start && currentTime < end) {
+            // text.style.backgroundColor = speakerColors[speaker - 1];
             text.style.backgroundColor = theme.palette.primary.main;
             text.style.color = '#000';
           }


### PR DESCRIPTION
Alle transcript functionaliteit die we eerst hadden werkt nu ook met de echte timestamped transcripts, i.e., springen van audio naar tekst en vice versa.

Ik heb de scroll behavior van het transcript veranderd naar `center` ipv `start`, omdat de gehighlighte tekst anders verborgen is onder de top bar wanneer je terug gaat in de audio (dit was nu extra duidelijk omdat we nu zinnen gebruiken ipv paragrafen).
Voor terug gaan in het transcript was `center` niet nodig (top bar verdwijnt wanneer je `start` hebt), maar ik heb het voor consistentie wel gedaan. Als `start` jullie handiger lijkt kunnen we dat gewoon terugdraaien.

Ik heb ook alvast de code voor speaker highlights toegevoegd. Die werkt, maar omdat speaker diarisation niet accuraat genoeg is heb ik het voor nu in comments gezet.

Transcript van WipeOut is nog van de oude audio, wat betekent dat het transcript aan het einde een stuk tekst heeft die niet werkt met de audio. Dus we moeten dan nog het transcript van WipeOut updaten.