### PR TITLE
Add action button with mode for autoscrolling in transcript

### DIFF
--- a/src/components/AudioTranscript.js
+++ b/src/components/AudioTranscript.js
@@ -61,7 +61,7 @@ function AudioTranscript(props) {
   const transcriptJSON = episode.sentence_transcript;
   const [transcript, setTranscript] = useState(null);
   const [currentText, setCurrentText] = useState(null);
-  const [isFocusMode, setIsFocusMode] = useState(false);
+  const [isFocusMode, setIsFocusMode] = useState(true);
   const theme = useTheme();
   const textRefs = useRef([]);
   const classes = useStyles();


### PR DESCRIPTION
Ik heb een floating action button rechts onder toegevoegd die de gebruiker van modus kan laten switchen (autoscroll aan of uit). 

We hadden besproken in de meeting dat wanneer de gebruiker scrollt, autoscroll weer uit gaat. Dat gebeurt nu alleen voor `wheel` (muis) en `touchmove` (touchscreen) events, omdat `scroll` event niet mogelijk is want autoscroll gebruikt dat, dus dan zou die altijd meteen de autoscroll modus uit zichzelf verlaten. Andere scroll manieren via scrollbar of arrow keys worden nu dus niet gevangen. Daarom heb ik de optie erin gelaten om handmatig de modus te switchen (autoscroll aan=oranje, uit=grijs). 